### PR TITLE
fix typo in link for creating a video source

### DIFF
--- a/morevideos.html
+++ b/morevideos.html
@@ -175,7 +175,7 @@
 </div>
 
 <div class="alert alert-primary" role="alert">
-  Check out <a href=">https://github.com/glouel/AerialCommunity/blob/master/CreatingASource.md">instructions here</a> on how to create your own video sources.
+  Check out <a href="https://github.com/glouel/AerialCommunity/blob/master/CreatingASource.md">instructions here</a> on how to create your own video sources.
 </div>
 
 


### PR DESCRIPTION
Caught an extra `>` as a typo at the beginning of a link.

(I got to https://aerialscreensaver.github.io/morevideos.html via "Get more videos…" in the aerial 2.0.7 pref pane)